### PR TITLE
Session variable conflict with Cacti reports causes SQL query error

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ community.  After that you should open a feature request on
 
 * security: Fix potential security exposure with unserialize() function
 
+* issue#109: Session variable conflict with Cacti reports causes PHP warning
+
 --- 1.1.3 ---
 
 * issue#37: When adding a new template, changing the drop down box and clicking

--- a/reports.php
+++ b/reports.php
@@ -259,7 +259,7 @@ function standard() {
 			),
 	);
 
-	validate_store_request_vars($filters, 'sess_reports');
+	validate_store_request_vars($filters, 'sess_reportit_reports');
 	/* ================= Input validation ================= */
 
 	if ($reportAdmin) {


### PR DESCRIPTION
Report it uses the same variable name as cacti reports.
Other variables are without conflict